### PR TITLE
eventsテーブルにimageカラムを追加

### DIFF
--- a/database/migrations/2021_08_25_105423_add_img_to_events_table.php
+++ b/database/migrations/2021_08_25_105423_add_img_to_events_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddImgToEventsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->string('image');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('image');
+        });
+    }
+}


### PR DESCRIPTION
<img width="1242" alt="Screen Shot 2021-08-25 at 7 34 53 PM" src="https://user-images.githubusercontent.com/80045643/130783684-68be228a-6c03-4f2a-a365-f42c2bf650c3.png">
イベント一覧にてそそれぞれの画像をイベント名とマッチさせて反映させるためにDBに新しいカラムを追加させていただきました。